### PR TITLE
Fix GCC declaration-after-statement error

### DIFF
--- a/src/ftrace.c
+++ b/src/ftrace.c
@@ -55,8 +55,7 @@ static void notrace fh_trace_thunk(unsigned long ip, unsigned long parent_ip, st
 #else
 static void notrace fh_trace_thunk(unsigned long ip, unsigned long parent_ip, struct ftrace_ops *ops, struct ftrace_regs *fregs)
 {
-  struct pt_regs *regs;
-  regs = ftrace_get_regs(fregs);
+  struct pt_regs *regs = ftrace_get_regs(fregs);
 #endif
   struct ftrace_hook *hook = to_ftrace_hook(ops);
 


### PR DESCRIPTION
Since upgrading to Linux v5.18 in Nixpkgs, we've been seeing an
"ISO C90 forbids mixed declarations and code" error from GCC.

This patch fixes it by initializing regs as part of its declaration,
meaning hook will no longer be declared after a statement.

Signed-off-by: Alyssa Ross <hi@alyssa.is>